### PR TITLE
v0.0.118 custom

### DIFF
--- a/lightning-background-processor/Cargo.toml
+++ b/lightning-background-processor/Cargo.toml
@@ -22,11 +22,11 @@ default = ["std"]
 
 [dependencies]
 bitcoin = { version = "0.29.0", default-features = false }
-lightning = { version = "0.0.118", path = "../lightning", default-features = false }
-lightning-rapid-gossip-sync = { version = "0.0.118", path = "../lightning-rapid-gossip-sync", default-features = false }
+lightning = { path = "../lightning", default-features = false }
+lightning-rapid-gossip-sync = { path = "../lightning-rapid-gossip-sync", default-features = false }
 
 [dev-dependencies]
 tokio = { version = "1.14", features = [ "macros", "rt", "rt-multi-thread", "sync", "time" ] }
-lightning = { version = "0.0.118", path = "../lightning", features = ["_test_utils"] }
+lightning = { path = "../lightning", features = ["_test_utils"] }
 lightning-invoice = { version = "0.26.0", path = "../lightning-invoice" }
-lightning-persister = { version = "0.0.118", path = "../lightning-persister" }
+lightning-persister = { path = "../lightning-persister" }

--- a/lightning-block-sync/Cargo.toml
+++ b/lightning-block-sync/Cargo.toml
@@ -19,11 +19,11 @@ rpc-client = [ "serde_json", "chunked_transfer" ]
 
 [dependencies]
 bitcoin = "0.29.0"
-lightning = { version = "0.0.118", path = "../lightning" }
+lightning = { path = "../lightning" }
 tokio = { version = "1.0", features = [ "io-util", "net", "time" ], optional = true }
 serde_json = { version = "1.0", optional = true }
 chunked_transfer = { version = "1.4", optional = true }
 
 [dev-dependencies]
-lightning = { version = "0.0.118", path = "../lightning", features = ["_test_utils"] }
+lightning = { path = "../lightning", features = ["_test_utils"] }
 tokio = { version = "1.14", features = [ "macros", "rt" ] }

--- a/lightning-invoice/Cargo.toml
+++ b/lightning-invoice/Cargo.toml
@@ -21,7 +21,7 @@ std = ["bitcoin_hashes/std", "num-traits/std", "lightning/std", "bech32/std"]
 
 [dependencies]
 bech32 = { version = "0.9.0", default-features = false }
-lightning = { version = "0.0.118", path = "../lightning", default-features = false }
+lightning = { path = "../lightning", default-features = false }
 secp256k1 = { version = "0.24.0", default-features = false, features = ["recovery", "alloc"] }
 num-traits = { version = "0.2.8", default-features = false }
 bitcoin_hashes = { version = "0.11", default-features = false }
@@ -30,6 +30,6 @@ serde = { version = "1.0.118", optional = true }
 bitcoin = { version = "0.29.0", default-features = false }
 
 [dev-dependencies]
-lightning = { version = "0.0.118", path = "../lightning", default-features = false, features = ["_test_utils"] }
+lightning = { path = "../lightning", default-features = false, features = ["_test_utils"] }
 hex = "0.4"
 serde_json = { version = "1"}

--- a/lightning-net-tokio/Cargo.toml
+++ b/lightning-net-tokio/Cargo.toml
@@ -16,9 +16,9 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 bitcoin = "0.29.0"
-lightning = { version = "0.0.118", path = "../lightning" }
+lightning = { path = "../lightning" }
 tokio = { version = "1.0", features = [ "rt", "sync", "net", "time" ] }
 
 [dev-dependencies]
 tokio = { version = "1.14", features = [ "macros", "rt", "rt-multi-thread", "sync", "net", "time" ] }
-lightning = { version = "0.0.118", path = "../lightning", features = ["_test_utils"] }
+lightning = { path = "../lightning", features = ["_test_utils"] }

--- a/lightning-persister/Cargo.toml
+++ b/lightning-persister/Cargo.toml
@@ -15,7 +15,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 bitcoin = "0.29.0"
-lightning = { version = "0.0.118", path = "../lightning" }
+lightning = { path = "../lightning" }
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.48.0", default-features = false, features = ["Win32_Storage_FileSystem", "Win32_Foundation"] }
@@ -24,5 +24,5 @@ windows-sys = { version = "0.48.0", default-features = false, features = ["Win32
 criterion = { version = "0.4", optional = true, default-features = false }
 
 [dev-dependencies]
-lightning = { version = "0.0.118", path = "../lightning", features = ["_test_utils"] }
+lightning = { path = "../lightning", features = ["_test_utils"] }
 bitcoin = { version = "0.29.0", default-features = false }

--- a/lightning/src/blinded_path/mod.rs
+++ b/lightning/src/blinded_path/mod.rs
@@ -105,7 +105,7 @@ impl BlindedPath {
 	///
 	/// [`ForwardTlvs`]: crate::blinded_path::payment::ForwardTlvs
 	//  TODO: make all payloads the same size with padding + add dummy hops
-	pub(crate) fn new_for_payment<ES: EntropySource + ?Sized, T: secp256k1::Signing + secp256k1::Verification>(
+	pub fn new_for_payment<ES: EntropySource + ?Sized, T: secp256k1::Signing + secp256k1::Verification>(
 		intermediate_nodes: &[payment::ForwardNode], payee_node_id: PublicKey,
 		payee_tlvs: payment::ReceiveTlvs, htlc_maximum_msat: u64, entropy_source: &ES,
 		secp_ctx: &Secp256k1<T>

--- a/lightning/src/offers/invoice_request.rs
+++ b/lightning/src/offers/invoice_request.rs
@@ -876,7 +876,7 @@ impl TryFrom<Vec<u8>> for InvoiceRequest {
 			Some(signature) => signature,
 		};
 		let message = TaggedHash::new(SIGNATURE_TAG, &bytes);
-		merkle::verify_signature(&signature, message, contents.payer_id)?;
+		merkle::verify_signature(&signature, &message, contents.payer_id)?;
 
 		Ok(InvoiceRequest { bytes, contents, signature })
 	}
@@ -1013,7 +1013,7 @@ mod tests {
 		assert_eq!(invoice_request.payer_note(), None);
 
 		let message = TaggedHash::new(SIGNATURE_TAG, &invoice_request.bytes);
-		assert!(merkle::verify_signature(&invoice_request.signature, message, payer_pubkey()).is_ok());
+		assert!(merkle::verify_signature(&invoice_request.signature, &message, payer_pubkey()).is_ok());
 
 		assert_eq!(
 			invoice_request.as_tlv_stream(),


### PR DESCRIPTION
In this branch we just update to a specific hash of rust-lightning with the taggedhash tweaks we need for ldk-sample/lndk. We need the Cargo.toml changes to make sure we're using the exact same rust-lightning dependency everywhere, else we get version conflict errors in lndk.

We'll just use this temporary branch until ldk v119 comes out :)